### PR TITLE
Correct the Github source link for session storage

### DIFF
--- a/sessionstorage/index.html
+++ b/sessionstorage/index.html
@@ -70,7 +70,7 @@
     
   <script src="js/main.js"></script>
 
-<a href="https://github.com/samdutton/simpl/blob/master/sessionStorage/index.html" title="View source for this page on github" id="viewSource">View source on github</a>
+<a href="https://github.com/samdutton/simpl/blob/master/sessionstorage/index.html" title="View source for this page on github" id="viewSource">View source on github</a>
 </div> 
 <script src="../js/lib/ga.js"></script>
 </body>


### PR DESCRIPTION
Link was broken, should be `sessionstorage` instead of `sessionStorage`.
