### PR TITLE
Screencapture works in "standard" Chrome as well. Provided a SSL connection.

### DIFF
--- a/screencapture/index.html
+++ b/screencapture/index.html
@@ -36,7 +36,7 @@ video {
     <button id="btn2" onclick="call()">Call</button>
     <button id="btn3" onclick="hangup()">Hang Up</button>
   </div>
-  <p>This demo currently requires Chrome Canary with screen capture support enabled from about:flags.</p>
+  <p>This demo requires a SSL connection, with screen capture support enabled from about:flags.</p>
   <p>View the console to see what's happening. The <code>RTCPeerConnection</code> objects <code>pc1</code> and <code>pc2</code> are in global scope, so you can inspect them in the console as well.</p>
   <p>Code in this example used by kind permission of Vikas Marwaha and Justin Uberti.</p>
   <p>For more information about RTCPeerConnection, see <a href="http://www.html5rocks.com/en/tutorials/webrtc/basics/" title="HTML5 Rocks article about WebRTC by Sam Dutton">Getting Started With WebRTC</a>.</p>


### PR DESCRIPTION
Canary is not needed for the demo to work. A SSL connection on the other hand
seems to be required (PermissionDeniedError).

I'm not sure if other demos also need a SSL connection so I did not commit
something like:

```
if (window.location.protocol != "https:") {
  window.location.href = "https:" +
    window.location.href.substring(window.location.protocol.length);
}
```

I was also thinking about adding:

```
<a href="javascript:ssl">a SSL connection</a>
```

link, not sure how you feel about that though.
