### PR TITLE
Change selector method

### DIFF
--- a/xhr/js/main.js
+++ b/xhr/js/main.js
@@ -4,7 +4,7 @@ xhr.open("GET", "data.json");
 xhr.onreadystatechange = function() {
   if (xhr.readyState === 4 && xhr.status === 200) {
     var data = JSON.parse(xhr.responseText);
-    document.querySelector("#data").innerHTML = JSON.stringify(data);
+    document.getElementById("data").innerHTML = JSON.stringify(data);
   }
 }
 


### PR DESCRIPTION
If you can use getElementById or getElementsByClassName is recommendable over querySelector and querySelectorAll in terms of better performance; jsperf reference: http://jsperf.com/getelementbyid-vs-queryselector/11
