### PR TITLE
Update the battery example to match the spec

### DIFF
--- a/battery/js/main.js
+++ b/battery/js/main.js
@@ -4,13 +4,21 @@ function log(message){
   document.querySelector("#data").innerHTML += message + "<br />";
 }
 
-if (battery) {
+function logBattery(battery) {
 	log("Battery level: " + battery.level);
 	log("Battery charging: " + battery.charging);
 	log("Battery discharging time: ", battery.dischargingTime);
 	battery.addEventListener("chargingchange", function(e) {
 	  log("Battery chargingchange event: " + battery.charging);
 	}, false);
+}
+
+if(navigator.getBattery) {
+	navigator.getBattery().then(logBattery, function() {
+		log("There was an error while getting the battery state.");
+	});
+} else if (battery) {
+	logBattery(battery);
 } else {
 	log("Shame! The Battery API is not supported on this platform.")
 }


### PR DESCRIPTION
In the latest version of the Battery Status API draft (http://www.w3.org/TR/battery-status/), a BatteryManager object is obtained by calling `navigator.getBattery()` , which return a promise resolving into the object. This version of the draft is the one currently implemented in Chrome >= 38, and this PR adds should make the battery example compatible with these changes (while retaining backward compatibility with the old `navigator.battery`).
