### PR TITLE
Update main.js

### DIFF
--- a/getusermedia/sources/js/main.js
+++ b/getusermedia/sources/js/main.js
@@ -24,7 +24,7 @@ function gotSources(sourceInfos) {
   }
 }
 
-if (typeof MediaStreamTrack === 'undefined'){
+if (typeof MediaStreamTrack.getSources === 'undefined'){
   alert('This browser does not support MediaStreamTrack.\n\nTry Chrome Canary.');
 } else {
   MediaStreamTrack.getSources(gotSources);


### PR DESCRIPTION
Fixed method to check support 'MediaStreamTrack' on Firefox >= Version 34.