### PR TITLE
Update link for canvas cheat sheet

### DIFF
--- a/canvas/index.html
+++ b/canvas/index.html
@@ -26,7 +26,7 @@
   <canvas height="190" width="640">Sorry! Your browser doesn't support canvas.</canvas>
   <script src="js/main.js"></script>
 
-  <p><a href="http://blog.nihilogic.dk/2009/02/html5-canvas-cheat-sheet.html" title="Nihilogic Canvas Cheat Sheet">Cheat sheet</a></p>
+  <p><a href="http://web.archive.org/web/20140526055814/http://www.nihilogic.dk/labs/canvas_sheet/HTML5_Canvas_Cheat_Sheet.pdf" title="Nihilogic Canvas Cheat Sheet">Cheat sheet</a></p>
 
   <p><a href="https://developer.mozilla.org/en-US/docs/HTML/Canvas" title="Canvas documentation home on MDN">Canvas documentation on Mozilla Developer Network</a></p>
 


### PR DESCRIPTION
Hi Sam,

I wasn't aware of this collection of resources, this is great! I noticed that [the link](http://blog.nihilogic.dk/2009/02/html5-canvas-cheat-sheet.html) pointing to a canvas cheat sheet is not working.

I managed to find (what I think is) the resource you were linking to in the Web Archive and replaced the reference, but by all means feel free to ditch the PR and use another link you think is appropriate.

Thanks!