### PR TITLE
Add muted to avoid chrome blocking videos

### DIFF
--- a/videoalpha/index.html
+++ b/videoalpha/index.html
@@ -51,9 +51,9 @@ gtag('config', 'UA-33848682-1');
 </head>
 <body>
 
-  <video id="video1" autoplay src="video/dancer1.webm" loop></video>
-  <video id="video2" autoplay src="video/soccer1.webm" loop></video>
-  <video id="chrome" class="transparent" src="video/chrome.webm" loop></video>
+  <video id="video1" autoplay src="video/dancer1.webm" loop muted></video>
+  <video id="video2" autoplay src="video/soccer1.webm" loop muted></video>
+  <video id="chrome" class="transparent" src="video/chrome.webm" loop muted></video>
 
   <div id="container">
 


### PR DESCRIPTION
This is the case across the internet: demos of alpha transparency videos are breaking because of the chrome changes to block autoplaying videos with audio. A simple muted flag fixes this.