### PR TITLE
Fix mediarecorder/audio-only example

### DIFF
--- a/mediarecorder/audio-only/js/main.js
+++ b/mediarecorder/audio-only/js/main.js
@@ -37,7 +37,7 @@ downloadButton.onclick = download;
 
 // window.isSecureContext could be used for Chrome
 var isSecureOrigin = location.protocol === 'https:' ||
-location.host === 'localhost';
+  location.host.includes('localhost');
 if (!isSecureOrigin) {
   alert('getUserMedia() must be run from a secure origin: HTTPS or localhost.' +
     '\n\nChanging protocol to HTTPS');
@@ -45,8 +45,8 @@ if (!isSecureOrigin) {
 }
 
 var constraints = {
-  audio: false,
-  video: true
+  audio: true,
+  video: false
 };
 
 navigator.mediaDevices.getUserMedia(
@@ -95,7 +95,7 @@ function toggleRecording() {
 
 // The nested try blocks will be simplified when Chrome 47 moves to Stable
 function startRecording() {
-  var options = {mimeType: 'audio/mp3'};
+  var options = {mimeType: 'audio/webm'};
   recordedBlobs = [];
   try {
     mediaRecorder = new MediaRecorder(window.stream, options);

--- a/mediarecorder/video-only/js/main.js
+++ b/mediarecorder/video-only/js/main.js
@@ -37,7 +37,7 @@ downloadButton.onclick = download;
 
 // window.isSecureContext could be used for Chrome
 var isSecureOrigin = location.protocol === 'https:' ||
-location.host === 'localhost';
+  location.host.includes('localhost');
 if (!isSecureOrigin) {
   alert('getUserMedia() must be run from a secure origin: HTTPS or localhost.' +
     '\n\nChanging protocol to HTTPS');


### PR DESCRIPTION
This PR aims at making the *mediarecorder/audio-only* example functional in the latest Chrome and Firefox.

- [audio-only] Fix errors in `constraints` (seemingly typos).
- [audio-only] Update the default `mimeType` of `startRecording()` to 'audio/webm'.
  This fixes `MediaRecorder` exceptions being raised in the latest Chrome 81 and Firefox 77.
- [audio-only/video-only] Update secure origin check per mediarecorder/js/main.js