### PR TITLE
Added Safari support for the mediarecorder examples

### DIFF
--- a/mediarecorder/audio-only/js/main.js
+++ b/mediarecorder/audio-only/js/main.js
@@ -80,6 +80,7 @@ function handleDataAvailable(event) {
 
 function handleStop(event) {
   console.log('Recorder stopped: ', event);
+  console.log('Recorded Blobs: ', recordedBlobs);
 }
 
 function toggleRecording() {
@@ -129,12 +130,12 @@ function startRecording() {
 
 function stopRecording() {
   mediaRecorder.stop();
-  console.log('Recorded Blobs: ', recordedBlobs);
   recordedVideo.controls = true;
 }
 
 function play() {
-  var superBuffer = new Blob(recordedBlobs, {type: 'audio/mp3'});
+  var type = (recordedBlobs[0] || {}).type;
+  var superBuffer = new Blob(recordedBlobs, { type });
   recordedVideo.src = window.URL.createObjectURL(superBuffer);
 }
 

--- a/mediarecorder/js/main.js
+++ b/mediarecorder/js/main.js
@@ -81,6 +81,7 @@ function handleDataAvailable(event) {
 
 function handleStop(event) {
   console.log('Recorder stopped: ', event);
+  console.log('Recorded Blobs: ', recordedBlobs);
 }
 
 function toggleRecording() {
@@ -129,12 +130,12 @@ function startRecording() {
 
 function stopRecording() {
   mediaRecorder.stop();
-  console.log('Recorded Blobs: ', recordedBlobs);
   recordedVideo.controls = true;
 }
 
 function play() {
-  var superBuffer = new Blob(recordedBlobs, {type: 'video/webm'});
+  var type = (recordedBlobs[0] || {}).type;
+  var superBuffer = new Blob(recordedBlobs, { type });
   recordedVideo.src = window.URL.createObjectURL(superBuffer);
 }
 

--- a/mediarecorder/video-only/js/main.js
+++ b/mediarecorder/video-only/js/main.js
@@ -93,6 +93,7 @@ function handleDataAvailable(event) {
 
 function handleStop(event) {
   console.log('Recorder stopped: ', event);
+  console.log('Recorded Blobs: ', recordedBlobs);
 }
 
 function toggleRecording() {
@@ -142,12 +143,12 @@ function startRecording() {
 
 function stopRecording() {
   mediaRecorder.stop();
-  console.log('Recorded Blobs: ', recordedBlobs);
   recordedVideo.controls = true;
 }
 
 function play() {
-  var superBuffer = new Blob(recordedBlobs, {type: 'video/webm'});
+  var type = (recordedBlobs[0] || {}).type;
+  var superBuffer = new Blob(recordedBlobs, { type });
   recordedVideo.src = window.URL.createObjectURL(superBuffer);
 }
 


### PR DESCRIPTION
This PR is to update the *mediarecorder* examples functional in Safari (with the `MediaRecorder` feature enabled via  "Develop > Experimental Features > [v] MediaRecorder").
