### PR TITLE
Fix source link to "/inputnames" not "/inputtypes"

### DIFF
--- a/inputnames/index.html
+++ b/inputnames/index.html
@@ -400,7 +400,7 @@ label {
 
   </form>
 
-  <a href="https://github.com/samdutton/simpl/blob/gh-pages/inputtypes" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
+  <a href="https://github.com/samdutton/simpl/blob/gh-pages/inputnames" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 
 </div></body>
 </html>


### PR DESCRIPTION
Fixed "input names" demo webpage URL for source link, since it currently points to the "input TYPES" source folder on GitHub.🤦‍♂️
