### PR TITLE
Source link URL "/video/overlay" not "/videooverlay"

### DIFF
--- a/video/overlay/index.html
+++ b/video/overlay/index.html
@@ -91,7 +91,7 @@ document.querySelector('video').addEventListener('loadedmetadata',
   });
 </script>
 
-  <a href="https://github.com/samdutton/simpl/blob/gh-pages/videooverlay" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
+  <a href="https://github.com/samdutton/simpl/blob/gh-pages/video/overlay" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
 
 </div>
 


### PR DESCRIPTION
FIXED:
<a href="https://github.com/samdutton/simpl/blob/gh-pages/video/overlay" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>

BUG:
<a href="https://github.com/samdutton/simpl/blob/gh-pages/videooverlay" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
